### PR TITLE
verbosity flag added to gtfs.loader.load

### DIFF
--- a/gtfs/loader.py
+++ b/gtfs/loader.py
@@ -3,34 +3,36 @@ import feed
 from entity import *
 import sys
 
-def load(feed_filename, db_filename=":memory:"):
-  schedule = Schedule( db_filename ) 
+def load(feed_filename, db_filename=":memory:", verbose=True):
+  schedule = Schedule( db_filename )
   schedule.create_tables()
-  
+
   fd = feed.Feed( feed_filename )
 
-  for gtfs_class in (Agency, 
-                     Route, 
-		     Stop,
-		     Trip, 
-		     StopTime,
-		     ServicePeriod, 
-		     ServiceException, 
-		     Fare,
-		     FareRule,
-		     ShapePoint,
-		     Frequency,
-		     Transfer,
-		     ):
+  for gtfs_class in (Agency,
+                     Route,
+                     Stop,
+                     Trip,
+                     StopTime,
+                     ServicePeriod,
+                     ServiceException,
+                     Fare,
+                     FareRule,
+                     ShapePoint,
+                     Frequency,
+                     Transfer,
+                     ):
 
-    print "loading %s"%gtfs_class
-   
+    if verbose:
+      print "loading %s"%gtfs_class
+
     try:
       for i, record in enumerate( fd.get_table( gtfs_class.TABLENAME+".txt" ) ):
         if i%500==0:
-	  sys.stdout.write(".")
-	  sys.stdout.flush()
-	  schedule.session.commit()
+          if verbose:
+              sys.stdout.write(".")
+              sys.stdout.flush()
+          schedule.session.commit()
 
         instance = gtfs_class( **record.to_dict() )
         schedule.session.add( instance )


### PR DESCRIPTION
This adds a `verbosity` optional named argument to `gfts.loader.load`. If it’s set to `False`, the function won’t print anything.
